### PR TITLE
Add a list_departments tool to the Explorer toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ This server provides eleven tools across two APIs:
 | `explore_demographics` | Explorer | Institutional | Audience geographic and demographic data |
 | `explore_mention_sources` | Explorer | Institutional | Source/outlet analysis for mentions |
 | `explore_journals` | Explorer | Institutional | Journal metrics, rankings, and search |
+| `list_departments` | Explorer | Institutional | List your institution's departments and their IDs |
 
 All Explorer tools additionally accept `researcher_id` and `grant_id` filters (Dimensions IDs), and an `identifiers` parameter that scopes a query to a raw list of scholarly identifiers - the server builds the corresponding identifier list for you. Explorer responses also include sentiment data (`sentiment-analysis-totals` on research outputs, `sentiment-analysis` on X/Bluesky mentions).
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -128,3 +128,8 @@ Get aggregated mention data by journal — journal names, ISSNs, and mention cou
 - `type`: Filter by research output type
 - `timeframe`, `published_after`/`published_before`: Time filters
 - `identifiers` / `identifier_list_id`: Scope to a specific set of outputs
+
+### `list_departments`
+List the institutional departments configured in your Explorer instance — each with its `id` and `name`.
+
+The `id` is the value to pass to the `department_id` filter on the other Explorer tools (e.g. `explore_research_outputs`). Only available to institutions with a data integration; those without one get an empty list. Takes no arguments and fetches every page for you, returning the full department set.

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -43,6 +43,7 @@ const TOOL_TITLES = {
   explore_demographics: 'Explore demographics',
   explore_mention_sources: 'Explore mention sources',
   explore_journals: 'Explore journals',
+  list_departments: 'List departments',
 };
 
 function detailsPageTools(resolveDetails) {
@@ -1605,6 +1606,57 @@ function explorerTools(resolveExplorer) {
             },
           ],
           structuredContent: data,
+        };
+      },
+    },
+    list_departments: {
+      definition: {
+        name: 'list_departments',
+        description: 'List the institutional departments in your Altmetric Explorer instance. Returns every department with its id and name; use a department\'s id as a value for the department_id filter on the other Explorer tools (e.g. explore_research_outputs). Only available to institutions with a data integration (PURE, Elements, OAI-PMH, or CSV); institutions without one return an empty list. Takes no arguments and fetches every page for you, returning your institution\'s full department set. Requires Explorer API credentials.',
+        annotations: {
+          readOnlyHint: true,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      handler: async () => {
+        // The endpoint paginates (100 max per page), but departments are a
+        // small, bounded set, so fetch every page and return the full list in
+        // one call. MAX_PAGES is a defensive cap against a runaway loop.
+        const MAX_PAGES = 100;
+        const departments = [];
+        let meta;
+        let page = 1;
+        let totalPages = 1;
+
+        do {
+          const filters = buildFilters({ page_number: page, page_size: 100 }, ['page_number', 'page_size']);
+          const data = await explorerRequest('/explorer/api/departments', filters);
+
+          if (Array.isArray(data.data)) {
+            departments.push(...data.data);
+          }
+          meta = data.meta;
+          totalPages = data.meta?.response?.['total-pages'] || 1;
+          page += 1;
+        } while (page <= totalPages && page <= MAX_PAGES);
+
+        const summary =
+          `Departments\n` +
+          `Showing ${departments.length} departments`;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: summary,
+            },
+          ],
+          structuredContent: { meta, data: departments },
         };
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "altmetric-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "altmetric-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@altmetric/identifiers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altmetric-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for Altmetric APIs - track research attention across news, policy, social media, and more",
   "mcpName": "com.altmetric.mcp/altmetric-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/altmetric/altmetric-mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/altmetric/altmetric-mcp/main/icon.svg",
@@ -24,7 +24,7 @@
     {
       "registryType": "npm",
       "identifier": "altmetric-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/test/tools_test.js
+++ b/test/tools_test.js
@@ -40,9 +40,10 @@ describe('Conditional Tool Registration', function () {
   const EXPLORER_TOOLS = [
     'explore_research_outputs', 'explore_attention_summary', 'explore_mentions',
     'explore_demographics', 'explore_mention_sources', 'explore_journals',
+    'list_departments',
   ];
 
-  it('returns all 11 tools when both APIs configured', function () {
+  it('returns all 12 tools when both APIs configured', function () {
     const allTools = createTools({ details: detailsResolver, explorer: explorerResolver });
     assert.deepStrictEqual(Object.keys(allTools).sort(), [...DETAILS_TOOLS, ...EXPLORER_TOOLS].sort());
   });
@@ -436,5 +437,47 @@ describe('MCP Tools', function () {
       const url = new URL(fetchStub.firstCall.args[0]);
       assert.strictEqual(url.searchParams.get('include'), '');
     });
+  });
+});
+
+describe('list_departments (Explorer)', function () {
+  let stub;
+
+  beforeEach(function () {
+    stub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(function () {
+    stub.restore();
+  });
+
+  const departmentsPage = (departments, totalPages) => ({
+    ok: true,
+    text: async () => JSON.stringify({
+      meta: { response: { 'total-results': totalPages * 100, 'total-pages': totalPages } },
+      data: departments,
+    }),
+  });
+
+  it('requests the departments endpoint signed with key and digest', async function () {
+    stub.resolves(departmentsPage([{ id: 'inst:group:a', type: 'department', attributes: { name: 'Biology' } }], 1));
+
+    const result = await toolHandlers.list_departments({});
+    const url = new URL(stub.firstCall.args[0]);
+
+    assert.strictEqual(url.pathname, '/explorer/api/departments');
+    assert.ok(url.searchParams.get('key'), 'key should be present');
+    assert.ok(url.searchParams.get('digest'), 'digest should be present');
+    assert.strictEqual(result.structuredContent.data.length, 1);
+  });
+
+  it('fetches every page and returns the full department set', async function () {
+    stub.onFirstCall().resolves(departmentsPage([{ id: 'a' }, { id: 'b' }], 2));
+    stub.onSecondCall().resolves(departmentsPage([{ id: 'c' }], 2));
+
+    const result = await toolHandlers.list_departments({});
+
+    assert.strictEqual(stub.callCount, 2);
+    assert.deepStrictEqual(result.structuredContent.data.map(d => d.id), ['a', 'b', 'c']);
   });
 });


### PR DESCRIPTION
Adds a `list_departments` Explorer tool that returns the calling institution's departments (`id` + `name`).

## Why

The six existing Explorer tools already accept a `department_id` filter, but there was no way for an MCP user to discover those IDs — you'd have to read them out of the Explorer UI. This tool closes that gap, mirroring how `explore_journals` pairs with the `journal_id` filter. It's backed by the `GET /explorer/api/departments` Explorer API endpoint.

## Details

- No arguments. The endpoint paginates (100/page), but departments are a small, bounded set, so the handler fetches every page and returns the full list in one call (capped defensively at 100 pages).
- Uses the existing Explorer `key` + `digest` auth — no new credentials or scope. `server.json` only gains a version bump.
- Registers under the existing Explorer toolset, so it appears automatically for any caller that already has the Explorer tools.

## How to verify

`npm test` — new tests cover the signed request to `/explorer/api/departments` and multi-page aggregation; the tool-registration test now asserts 12 tools.

## Notes

- Version bumped to `1.1.0` (`package.json`, `server.json` ×2, `package-lock.json`), so it is ready for `publish.sh`.
- Depends on the `GET /explorer/api/departments` endpoint being live in production.
