### PR TITLE
Add GitHub Actions workflow to run tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  test-result:
+    name: test-result
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Verify all matrix jobs passed
+        env:
+          RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$RESULT" != "success" ]; then
+            echo "One or more test jobs failed: $RESULT"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 .env
 .env.local
 .DS_Store
-.github
 
 # MCP Registry CLI tokens
 .mcpregistry_*


### PR DESCRIPTION
Adds a `test` workflow that runs the unit suite (`npm test`, 185 tests) on pushes and PRs to `main`, across Node 20 and 22 (matching the `engines: >=20.6.0` floor).

The integration tests are intentionally excluded, they need real Altmetric API credentials; the unit suite stubs all HTTP via Sinon/nock so it runs hermetically in CI.

Also drops `.github` from `.gitignore` (a boilerplate default from the initial commit) so the workflow can be tracked.

Once this merges and the check has run at least once, `test` can be added as a required status check on `main`.